### PR TITLE
Introduce a switch to select yum or dnf to be used for yum-based distros

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,3 +21,4 @@ jobs:
           exclude: "./.git/*" # Optional.
           check_all_files_with_shebangs: "true" # Optional.
           fail_on_error: "true"
+          shellcheck_flags: --severity=warning

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MAJOR=0
 MINOR=1
 RELEASE=1
 
-VERSION=$(MAJOR).$(MINOR)-$(RELEASE)$(DIST)
+VERSION=$(MAJOR).$(MINOR)-$(RELEASE)
 
 $(info Building version $(VERSION))
 
@@ -36,8 +36,10 @@ MAN_FILE_LOCATION=/usr/share/man/man1
 all:
 	$(error There is nothing to build here yet. Please use "make install" to install the config files)
 
+srpm: sources
+
 sources: 
-	tar czf ./smart-restart-$(VERSION).tar.gz --transform 's,^,smart-restart-$(VERSION)/,' bin conf Makefile smart-restart.spec doc/smart-restart.man1
+	tar czf ./smart-restart-v$(VERSION).tar.gz --transform 's,^,smart-restart-v$(VERSION)/,' bin conf Makefile smart-restart.spec doc/smart-restart.man1
 
 install: 
 	$(info Dest: $(DEST_DIR))

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
 DEST_DIR?=/
 PREFIX?=/usr/bin
 HOOK_DIR=
-DIST?=$(shell cut -d ":" -f6 /etc/system-release-cpe)
 
 MAJOR=0
-MINOR=1
-RELEASE=1
+MINOR=2
 
-VERSION=$(MAJOR).$(MINOR)-$(RELEASE)
+VERSION=v$(MAJOR).$(MINOR)
 
 $(info Building version $(VERSION))
 
@@ -16,7 +14,7 @@ $(info Building version $(VERSION))
 HOOK_DIR=/etc/dnf/plugins/post-transaction-actions.d
 HOOK_COMMAND=in
 
-ifeq ($(PKG_MANAGER),yum)
+ifeq ($(pkg_manager),yum)
 HOOK_DIR=/etc/yum/post-actions
 HOOK_COMMAND=install
 endif
@@ -39,7 +37,7 @@ all:
 srpm: sources
 
 sources: 
-	tar czf ./smart-restart-v$(VERSION).tar.gz --transform 's,^,smart-restart-v$(VERSION)/,' bin conf Makefile smart-restart.spec doc/smart-restart.man1
+	tar czf ./smart-restart-$(VERSION).tar.gz --transform 's,^,smart-restart-$(VERSION)/,' bin conf Makefile smart-restart.spec doc/smart-restart.man1
 
 install: 
 	$(info Dest: $(DEST_DIR))


### PR DESCRIPTION
Currently, `smart-restart` is only available for al2023 which uses dnf. This version adds a switch to use `yum` as well so we can ship `smart-restart` for al2 in a future release.

The makefile already can handle both, dnf and yum. This change adds a proper switch to the `smart-restart.spec` file so either the spec file automatically decides on the OS based on the `amzn2` macro, or can be overwritten using `--without yum`. Using this switch only changes the package manager, not the distro. The distro can still be overwritten using `-D "dist .amzn2023"` or `-D "dist .amzn2"`.

Example usage:
```
rpmbuild -bb --target noarch -D "dist .amzn2023" --with yum --nodeps smart-restart.spec
```

This will generate an RPM for the al2023 distro using yum (**This will NOT WORK. No yum on al2023**).