### PR TITLE
Support dnf5: libdnf5 actions plugin hook and needs-restarting subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,16 @@ CONF_DIR=/etc/smart-restart-conf.d
 
 HOOK_ACTION=install.action
 HOOK_ACTION_TEMPLATE=$(HOOK_ACTION).in
+
+# dnf5 loads post-transaction hooks through the libdnf5 actions plugin:
+# *.actions files under /etc/dnf/libdnf5-plugins/actions.d with a
+# "HOOK:PKG_FILTER:DIRECTION:OPTIONS:CMD" line format.
+ifeq ($(pkg_manager),dnf5)
+HOOK_DIR=/etc/dnf/libdnf5-plugins/actions.d
+HOOK_ACTION=smart-restart.actions
+HOOK_ACTION_TEMPLATE=install.actions.in
+endif
+
 DENYLIST_CONF_FILE=default-denylist
 MAN_FILE=smart-restart.1
 MAN_FILE_LOCATION=/usr/share/man/man1

--- a/bin/smart-restart.sh
+++ b/bin/smart-restart.sh
@@ -22,6 +22,16 @@ readonly POST_RESTART=("$CONF_PATH"/*post-restart)
 shopt -u nullglob
 
 SYSCTL_COMMAND="${SYSCTL_COMMAND:-systemctl}"
+# dnf5-only systems implement needs-restarting as a dnf5 subcommand (a
+# compat shim may still provide /usr/bin/needs-restarting). Detect the
+# active stack by what /usr/bin/dnf resolves to, so a side-installed dnf5
+# on a dnf4 system does not flip the tool. When this script runs from the
+# libdnf5 actions plugin hook, the calling dnf process still holds the
+# system repository lock, so the inner dnf5 must skip file locking to
+# avoid deadlocking on its parent transaction.
+if [[ -z "${NEEDS_RESTARTING_COMMAND:-}" ]] && [[ "$(readlink -f /usr/bin/dnf 2>/dev/null)" == *dnf5 ]]; then
+    NEEDS_RESTARTING_COMMAND="dnf5 needs-restarting --skip-file-locks"
+fi
 NEEDS_RESTARTING_COMMAND="${NEEDS_RESTARTING_COMMAND:-/usr/bin/needs-restarting}"
 
 IS_TESTING=${IS_TESTING:-}

--- a/conf/install.actions.in
+++ b/conf/install.actions.in
@@ -1,0 +1,4 @@
+# Run smart-restart after every transaction that installs or upgrades
+# packages. The libdnf5 actions plugin deduplicates identical expanded
+# commands, so this runs once per transaction.
+post_transaction:*:#COMMAND#::sh #PREFIX#/smart-restart.sh

--- a/smart-restart.spec
+++ b/smart-restart.spec
@@ -17,11 +17,22 @@ License:        Apache 2.0
 Requires:       yum-utils 
 Requires:       yum-plugin-post-transaction-actions
 %define         _plugin_path yum/post-actions/
+%define         _hook_file install.action
 %define         pkg_manager yum
+%elif 0%{?amzn} >= 2027
+# dnf5-only. needs-restarting is the dnf5 subcommand from dnf5-plugins,
+# and the post-transaction hook runs through the libdnf5 actions plugin
+# instead of dnf4's post-transaction-actions plugin.
+Requires:       dnf5-plugins
+Requires:       libdnf5-plugin-actions
+%define         _plugin_path dnf/libdnf5-plugins/actions.d/
+%define         _hook_file smart-restart.actions
+%define         pkg_manager dnf5
 %else
 Requires:       dnf-utils
 Requires:       dnf-plugin-post-transaction-actions
 %define         _plugin_path dnf/plugins/post-transaction-actions.d/
+%define         _hook_file install.action
 %define         pkg_manager dnf
 %endif
 
@@ -42,7 +53,7 @@ make DEST_DIR=$RPM_BUILD_ROOT pkg_manager=%{pkg_manager} PREFIX=%{_bindir} insta
 %files
 %defattr(-,root,root,-)
 %{_bindir}/%{name}.sh
-%config %{_sysconfdir}/%{_plugin_path}/install.action
+%config %{_sysconfdir}/%{_plugin_path}/%{_hook_file}
 %config %{_sysconfdir}/smart-restart-conf.d/default-denylist
 %doc %{_mandir}/man1/smart-restart.1*
 


### PR DESCRIPTION
dnf5-only systems (e.g. Amazon Linux 2027) drop the dnf4 post-transaction-actions plugin, leaving smart-restart uninstallable and its hook mechanism gone. Add first-class dnf5 support:

- Makefile: pkg_manager=dnf5 installs the hook through the libdnf5 actions plugin (*.actions file under /etc/dnf/libdnf5-plugins/actions.d) from a new conf/install.actions.in template
- smart-restart.sh: when dnf5 is present, default NEEDS_RESTARTING_COMMAND to 'dnf5 needs-restarting --skip-file-locks'. The actions plugin runs the hook synchronously inside the dnf transaction, which still holds the system repository lock, so the inner dnf5 must skip file locking or it deadlocks on its own parent (verified live: the hook child sat in 'Waiting for a lock on the system repository' naming its ancestor until killed)
- spec: on amzn >= 2027, require dnf5-plugins and libdnf5-plugin-actions, package the actions.d hook file

yum and dnf4 behavior is unchanged; the existing test suite passes and 'make install' output is identical for the default and yum modes.

Note: dnf5 < a3dcdacdc93c has a needs-restarting D-Bus regression (rpm-software-management/dnf5#2562) that breaks service detection in hook contexts regardless of this change; distros need that fix for the hook to be fully functional.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
